### PR TITLE
Updated Navbar of Chapters and Events Page

### DIFF
--- a/chapters/chapter.html
+++ b/chapters/chapter.html
@@ -144,16 +144,16 @@
     <header id="header" class="fixed-top d-flex align-items-center">
         <div class="container d-flex align-items-center">
             <img class="logo1" src="../assets/img/logo.jpeg" width="60px" height="60px" alt="logo" />
-            <h1 class="logo me-auto"><a href="index.html">OS-CODE</a></h1>
+            <h1 class="logo me-auto"><a href="index.html">OS-CODE</a></h1> 
 
             <nav id="navbar" class="navbar order-last order-lg-0">
                 <ul>
                     <li><a class="nav-link scrollto" style="text-decoration: none;" href="../index.html">Home</a></li>
                     <li><a class="nav-link scrollto" style="text-decoration: none;" href="../index.html#about">About</a></li>
-                    <li><a class="nav-link scrollto" style="text-decoration: none;" href="https://blog.oscode.co.in/">Blogs</a></li>
                     <li>
                         <a class="nav-link scrollto" style="text-decoration: none;" href="chapter.html">Chapters</a>
                     </li>
+                    <li><a class="nav-link scrollto" style="text-decoration: none;" href="https://blog.oscode.co.in/">Blogs</a></li>
                     <!-- <li><a class="nav-link scrollto" href="#team">Team</a></li> -->
                     <li><a href="../events/events.html" style="text-decoration: none;">Events</a></li>
                     <!-- <li class="dropdown">

--- a/events/events.html
+++ b/events/events.html
@@ -61,6 +61,7 @@
           </li>
           <!-- <li><a class="nav-link scrollto" href="#team">Team</a></li> -->
           <li><a class="nav-link scrollto" style="text-decoration: none;" href="https://blog.oscode.co.in/">Blogs</a></li>
+          <li><a href="../events/events.html" style="text-decoration: none;">Events</a></li>
           <!-- <li class="dropdown">
               <a href="#"
                 ><span>Drop Down</span> <i class="bi bi-chevron-down"></i


### PR DESCRIPTION
### Fixed issue #37 
- On clicking Chapters position of 'Blogs' and 'Chapters' is changing.
- On clicking Events it's disappearing from the navbar when we're on the Events page.
Updated Both the page's navbar as follows - 
**At Home -**
- Before & After-
 ![n1](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/108022893/44a7c692-6c07-42ee-9b7e-c8c62db65124)
**On the Chapters Page -**
- Before - 
![n2](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/108022893/649b9144-6945-4e78-ab25-80c21ab178dc)
- After -
 ![h2](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/108022893/f9651df9-49fc-400d-a6fd-aee22c2b1299)
**On the Events Page -**
- Before - 
![n3](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/108022893/f59bad28-0f94-4cb0-97a8-1e666ac476da)
- After -
![h3](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/108022893/3e954f8d-3949-4247-be5e-d58606433399)


