### PR TITLE
Solved issue #136: Fixed embedded link in logo bug [GSSOC'23]

### DIFF
--- a/events/events.html
+++ b/events/events.html
@@ -72,7 +72,7 @@
           height="60px"
           alt="logo"
         />
-        <h1 class="logo me-auto"><a href="index.html">OS-CODE</a></h1>
+        <h1 class="logo me-auto"><a href="../index.html">OS-CODE</a></h1>
 
         <nav id="navbar" class="navbar order-last order-lg-0">
           <ul>


### PR DESCRIPTION
**Description**
This PR adresses the issue #136. 

This PR fixes #
This PR fixes the bug in the events page where the embedded link in the logo was incorrect.

Changes made:
Changes made in .\events\events.html

Testing: 
The link is now working by pressing the logo on the events page.


PFA the image which displays the link on the bottom left when hovered over the logo

![oscode pr 1](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/102043379/c617d437-ba13-47e1-a9d7-d88f8e8c62cb)



@akshathar-navada Please let me know if there is any discrepancy. I have tried making the PR according to the code of conduct. Thankyou.
