### PR TITLE
Made the college name non-clickable

### DIFF
--- a/chapters/chapter.html
+++ b/chapters/chapter.html
@@ -333,38 +333,31 @@
 
               <ul class="faq-list accordion" data-aos="fade-up">
                 <li>
-                  <a href="#" target="_blank" rel="noopener noreferrer"
-                    >1. Bangalore Institute of Technology</a
+                  <a>1. Bangalore Institute of Technology</a
                   >
                 </li>
                 <li>
-                  <a href="#" target="_blank" rel="noopener noreferrer"
-                    >2. Dayananda Sagar University</a
+                  <a>2. Dayananda Sagar University</a
                   >
                 </li>
                 <li>
-                  <a href="#" target="_blank" rel="noopener noreferrer"
-                    >3. S J C institute of technology</a
+                  <a>3. S J C institute of technology</a
                   >
                 </li>
                 <li>
-                  <a href="#" target="_blank" rel="noopener noreferrer"
-                    >4. Sambhram Institute of Technology
+                  <a>4. Sambhram Institute of Technology
                   </a>
                 </li>
                 <li>
-                  <a href="#" target="_blank" rel="noopener noreferrer"
-                    >5. Sir M Vishwesariya Institute of Technology</a
+                  <a>5. Sir M Vishwesariya Institute of Technology</a
                   >
                 </li>
                 <li>
-                  <a href="#" target="_blank" rel="noopener noreferrer"
-                    >6. Sri Krishna Institute of Technology</a
+                  <a>6. Sri Krishna Institute of Technology</a
                   >
                 </li>
                 <li>
-                  <a href="#" target="_blank" rel="noopener noreferrer"
-                    >7. Vemana institute of technology</a
+                  <a>7. Vemana institute of technology</a
                   >
                 </li>
               </ul>


### PR DESCRIPTION
**Description**
Earlier in the Chapters Page, the college names were clickable, clicking which opened the same page in a new tab, converted this to non-clickable.

This PR fixes #317 

Thanks for assigning me this issue.


<!--
Thank you for contributing to OSCodeCommunitySite! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
