### PR TITLE
[testimonial item class] Responsiveness Issue of text overflowing out of the placards solved

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1515,7 +1515,7 @@ a:hover i {
   box-sizing: content-box;
   padding: 30px;
   margin: 30px 15px;
-  height: 400px;
+  height: 450px;
   transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
   box-shadow: rgba(136, 165, 191, 0.48) 6px 2px 16px 0px,
     rgba(255, 255, 255, 0.8) -6px -2px 16px 0px;


### PR DESCRIPTION
**Description**
*The webpage was having a responsiveness issue. In mobile sizes (specifically Samsung Galaxy S20 Ultra 412\*915) the text was overflowing out of some of the containers. Now, it is working perfectly fine*

This PR fixes #432 

##Before 
![os code 2](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/104912087/5f4f5d95-19b4-4ed3-95ba-8670d805d52c)
![os code 3](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/104912087/178b67b4-aacd-4ca2-a41e-6b3ca45ac171)

## After

https://github.com/OSCode-Community/OSCodeCommunitySite/assets/104912087/de289751-aea1-4fd3-b47a-99e892e81774

**Thank you sir for giving me this opportunity**



<!--
Thank you for contributing to OSCodeCommunitySite! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
