### PR TITLE
About us is updated to navigate to about us section

### DIFF
--- a/index.html
+++ b/index.html
@@ -962,7 +962,7 @@
             </form> -->
             <ul>
               <li>
-                <i class="bx bx-chevron-right"></i> <a href="#about">About us</a>
+                <i class="bx bx-chevron-right"></i> <a href="#mainabout">About us</a>
               </li>
               <li>
                 <i class="bx bx-chevron-right"></i> <a href="#benefits">Benefits</a>


### PR DESCRIPTION
**Description**
corrected the about us link in the footer section under community header. Now when the user clicks on the About us this will navigate to the about us(who we are )  section.

This PR fixes #453 

**Notes for Reviewers**
Now we can navigate to about us section by clicking the about us in the footer under the community section.
<img width="959" alt="Screenshot 2023-05-28 082703" src="https://github.com/OSCode-Community/OSCodeCommunitySite/assets/120104020/5f91b99a-2ac7-4e98-9a49-39eb5fd29571">



<!--
Thank you for contributing to OSCodeCommunitySite! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
