### PR TITLE
 you will be navigated to the address of os-code when you click on the text which is present in the footer section

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "liveServer.settings.port": 5501
+    "liveServer.settings.port": 5502
 }

--- a/index.html
+++ b/index.html
@@ -979,12 +979,17 @@
           <div class="col-lg-3 col-md-6 footer-contact">
             <h3>OS-Code</h3>
             <p>
-              OS-CODE headquarter, Shanbough<br>
-              Krinshappa Ln Mavalli, <br>
-              Bengaluru, Karnataka 560004<br>
-              <strong>Phone:</strong> +91-7667109405<br />
+                <a href="https://maps.google.com/maps?q=OS-CODE+headquarter%2C+Shanbough%2C+Krinshappa+Ln+Mavalli%2C+Bengaluru%2C+Karnataka+560004" target="_blank" style="text-decoration: underline;">
+                    OS-CODE headquarter, Shanbough<br>
+                    Krinshappa Ln Mavalli, <br>
+                    Bengaluru, Karnataka 560004
+                </a>
+                <br>
+                <strong>Phone:</strong> +91-7667109405<br />
             </p>
-          </div>
+        </div>
+        
+        
 
           <div class="col-lg-3 col-md-6 footer-links">
             <h4>Useful Links</h4>


### PR DESCRIPTION
In the footer section the os code text is underlined which is a link when you click on it then that address will open in google maps where you can clearly see the address .



like this 


![image](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/127650446/24015e7b-5020-4a81-a063-ee9b82dbbbd0)



after clicking ----


![image](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/127650446/009c9d7f-65f9-46c0-a39c-a351c26328b2)



Please Consider this under GSS0C_23 --- [ contributor]  : ) 