### PR TITLE
Updated style.css

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1456,7 +1456,7 @@ a:hover i {
 --------------------------------------------------------------*/
 
 #footer {
-  margin: auto;
+  margin: 0;
   width: 100%;
   color: var(--background-white);
   font-size: 14px;


### PR DESCRIPTION
Improve after footer extra space.

## Closes 

Closes #583 

<!-- Replace <`issue_number`> with the Issue number to link it with this PR -->
<!-- Example: Closes #1-->

<!-- #1 stands for the issue number you are fixing -->

## Description
There was some extra space after footer
## Screenshots

Previous Image:
![image](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/63789702/40911a43-a8c7-40b8-967e-7147e4367fb2)

After modification image:
![image](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/63789702/cb342ea3-b40a-4d85-a3a2-b0259b87b580)



## Note to reviewers
This issue is resolved from my side, I think contributors should view other issues.

## Checklist:


<!-- Tick the checkboxes to ensure you've done everything correctly => [x] represents a checkbox  -->

- [x] I have linked the PR to the correct issue.
- [x] I have read the [Contribution Guidelines](https://github.com/OSCode-Community/OSCodeCommunitySite/blob/master/CONTRIBUTING.md)
- [x] I have built and tested the changes, and they do not break or show any errors.

<!--
Thank you for contributing to OSCodeCommunitySite! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
