### PR TITLE
Updating transition for 'Testimonials' Section

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1302,6 +1302,8 @@ a:hover i {
     rgb(181, 181, 253),
     rgb(209, 209, 245)
   );
+  box-shadow: 0 0 0 #7b7bff, 0 0 0 #7b7bff;
+  transition: box-shadow 0.4s ease-in-out;
 }
 .carousel .carousel-item {
   color: #fcfafa;
@@ -1315,8 +1317,7 @@ a:hover i {
   /* transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275); */
 }
 .carousel-inner:hover {
-  transition: 0.4s ease-in-out;
-  box-shadow: 6px 6px 12px #16161c, -6px -6px 12px #7b7bff;
+  box-shadow: 6px 6px 12px #7b7bff, -6px -6px 12px #7b7bff;
 }
 .carousel .img-box {
   width: 145px;


### PR DESCRIPTION
Transition for 'Testimonials' section

## Closes

Closes #587 

## Description

When we hover out, the transition is fixed now

## Video



https://github.com/OSCode-Community/OSCodeCommunitySite/assets/101629997/45fd2f76-8a45-45ee-8e5f-8898f094d2a8


## Note to reviewers
- My cursor did not show up in the video but it is working
<!-- Add notes to reviewers if applicable -->

## Checklist:

<!--
<!-- Tick the checkboxes to ensure you've done everything correctly => [x] represents a checkbox  -->

- [x] I have linked the PR to the correct issue.
- [x] I have read the [Contribution Guidelines](https://github.com/OSCode-Community/OSCodeCommunitySite/blob/master/CONTRIBUTING.md)
- [x] I have built and tested the changes, and they do not break or show any errors.

<!--
Thank you for contributing to OSCodeCommunitySite! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
