### PR TITLE
Fixed white space in Chapter and Events page

### DIFF
--- a/assets/css/chapter.css
+++ b/assets/css/chapter.css
@@ -168,3 +168,17 @@
       max-height: 200px;
     }
   }
+
+  /* Fix white space */
+  @media (max-width:700px ){
+    section#hero.d-flex.align-items-center::before{
+      display:flex;
+  flex-direction: column;
+  width:100%;
+    margin:0px;
+    padding:0px;
+    overflow-x: hidden;
+    box-sizing:border-box;
+
+    }
+  }

--- a/assets/css/events.css
+++ b/assets/css/events.css
@@ -498,3 +498,16 @@
   .modifyRow{
     margin-top: 20px;
   }
+  /* Fix white space */
+  @media (max-width:713px){
+    .container.text-center.p.event-wrap.wrapping.aos-init.aos-animate {
+      display:flex;
+    flex-direction: column;
+    width:100%;
+      margin:0px;
+      padding:0px;
+      overflow: hidden;
+      box-sizing:border-box;
+  
+    }
+  }


### PR DESCRIPTION
## Closes

Closes #issue_number685 

## Description
 I have made a valuable contribution to the Chapter and Events page of the project. As a part of this initiative, 
I forked the repository and focused on improving the responsiveness of these pages to ensure a seamless user experience on smaller devices.

## Screenshots
Current behavior


![Screenshot (100)](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/114878264/3df1cfe6-6562-4bc0-9c94-b420a59b3dcb)

![Screenshot (99)](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/114878264/212ae680-b39e-413a-8111-dcb981daca54)

![Screenshot (97)](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/114878264/95cd9b7e-12ba-4e67-91d9-c8c7d4457e70)

![Screenshot (96)](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/114878264/42600e04-0a8b-452d-b383-c08fdf6f7d37)

**Work**
To achieve this, I employed media queries, a powerful CSS feature, to adapt the layout and styling of the Chapter and Events pages based on different screen sizes. I carefully analyzed the existing design and identified areas that required adjustments to optimize the pages for smaller devices such as mobile phones and tablets.

By utilizing media queries, I applied specific CSS rules and styles to ensure that the content on the Chapter and Events pages dynamically rearranges and adjusts itself to fit smaller screens. This involved modifying box-sizing, adjusting margins and paddings, and repositioning elements to provide optimal readability and usability.



## Checklist:

- [✅ ] I have linked the PR to the correct issue.
- [ ✅] I have read the [Contribution Guidelines](https://github.com/OSCode-Community/OSCodeCommunitySite/blob/master/CONTRIBUTING.md)
- [ ✅] I have built and tested the changes, and they do not break or show any errors.


Thank you so much for giving me this opportunity.


