### PR TITLE
💡 [FEAT]: ACCESSIBLE SOCIAL ANCHORS FOR FOOTER W/ A11Y PRINCIPLES

### DIFF
--- a/index.html
+++ b/index.html
@@ -576,8 +576,14 @@
             <div class="col-lg-4 col-md-6 shrink">
 
               <div class="count-box">
-                <a href="https://github.com/OSCode-Community" target="_blank" rel="noopener noreferrer">
-                  <i class="bi bi-github github-box"></i>
+                <a 
+                   href="https://github.com/OSCode-Community" 
+                   target="_blank" 
+                   aria-label="Visit us on Github"
+                   title="Github (External Link)"
+                   rel="noopener noreferrer"
+                  >
+                    <i class="bi bi-github github-box"></i>
                   <p>Github</p>
                 </a>
               </div>
@@ -586,9 +592,14 @@
 
             <div class="col-lg-4 col-md-6 mt-5 mt-md-0 shrink">
               <div class="count-box">
-                <a href="https://discordapp.com/channels/945676223101698060/945680318248128543/946084270693318686"
-                  target="_blank" rel="noopener noreferrer">
-                  <i class="bi bi-discord discord-box"></i>
+                <a 
+                   href="https://discordapp.com/channels/945676223101698060/945680318248128543/946084270693318686"
+                   target="_blank" 
+                   aria-label="Join with us on Discord"
+                   title="Discord (External Link)"
+                   rel="noopener noreferrer"
+                  >
+                    <i class="bi bi-discord discord-box"></i>
                   <p>Discord</p>
                 </a>
               </div>
@@ -597,8 +608,14 @@
 
             <div class="col-lg-4 col-md-6 mt-5 mt-lg-0 shrink">
               <div class="count-box">
-                <a href="https://www.linkedin.com/company/oscode/" target="_blank" rel="noopener noreferrer">
-                  <i class="bi bi-linkedin linkedin-box"></i>
+                <a 
+                   href="https://www.linkedin.com/company/oscode/" 
+                   target="_blank" 
+                   aria-label="Visit us on Linkedin"
+                   title="Linkedin (External Link)"
+                   rel="noopener noreferrer"
+                  >
+                    <i class="bi bi-linkedin linkedin-box"></i>
                   <p>LinkedIn</p>
                 </a>
               </div>
@@ -608,9 +625,14 @@
           <div class="row join shrink  ml-auto mr-auto">
             <div class="col-lg-4 col-md-6">
               <div class="count-box">
-                <a href="https://instagram.com/os_code_community?igshid=YmMyMTA2M2Y=" target="_blank"
-                  rel="noopener noreferrer">
-                  <i class="bi bi-instagram instagram-box"></i>
+                <a 
+                   href="https://instagram.com/os_code_community?igshid=YmMyMTA2M2Y=" 
+                   target="_blank"
+                   aria-label="Visit us on Instagram"
+                   title="Instagram (External Link)"
+                   rel="noopener noreferrer"
+                  >
+                    <i class="bi bi-instagram instagram-box"></i>
                   <p>Instagram</p>
                 </a>
               </div>
@@ -619,7 +641,13 @@
 
             <div class="col-lg-4 col-md-6 mt-5 mt-md-0 shrink">
               <div class="count-box">
-                <a href="https://twitter.com/OSCodeCommunity" target="_blank" rel="noopener noreferrer">
+                <a 
+                   href="https://twitter.com/OSCodeCommunity" 
+                   target="_blank" 
+                   aria-label="Visit us on Twitter"
+                   title="Twitter (External Link)"
+                   rel="noopener noreferrer"
+                  >
                   <i class="bi bi-twitter twitter-box"></i>
                   <p>Twitter</p>
                 </a>
@@ -628,7 +656,13 @@
 
             <div class="col-lg-4 col-md-6 mt-5 mt-lg-0 shrink">
               <div class="count-box">
-                <a href="https://t.me/+yNBAO5cbFLk3NTA1" target="_blank" rel="noopener noreferrer">
+                <a 
+                   href="https://t.me/+yNBAO5cbFLk3NTA1" 
+                   target="_blank" 
+                   aria-label="Join with us on Telegram"
+                   title="Telegram (External Link)"
+                   rel="noopener noreferrer"
+                  >
                   <i class="bi bi-telegram telegram-box"></i>
                   <p>Telegram</p>
                 </a>
@@ -1071,18 +1105,66 @@
     <div class="container py-4 modifiedFooter">
       <div class="social-links text-md-end pt-3 pt-md-0 socialLinkMod">
         <div class="textSocials">Stay in the loop?</div>
-        <a href="https://twitter.com/oscodecommunity" target="_blank" class="twitter"><i class="bx bxl-twitter"></i></a>
-        <a href="https://www.facebook.com/profile.php?id=100090940131222&mibextid=ZbWKwL" target="_blank"
-          class="facebook"><i class="bx bxl-facebook"></i></a>
-        <a href="https://www.instagram.com/os_code_community/" target="_blank" class="instagram"><i
-            class="bx bxl-instagram"></i></a>
-        <a href="https://www.youtube.com/@oscodecommunity" target="_blank" class="youtube"><i
-            class="fab fa-youtube"></i></a>
-        <a href="https://www.linkedin.com/company/oscode/" target="_blank" class="linkedin"><i
-            class="bx bxl-linkedin"></i></a>
-
-        <a href="https://discord.com/channels/945676223101698060" target="_blank" class="discord"><i class="fa-brands fa-discord"></i></a>
-
+        <a 
+           href="https://twitter.com/oscodecommunity" 
+           target="_blank" 
+           aria-label="Visit us on Twitter"
+           title="Twitter (External Link)"
+           rel="noopener noreferrer"
+           class="twitter"
+          >
+            <i class="bx bxl-twitter"></i>
+        </a>
+        <a 
+           href="https://www.facebook.com/profile.php?id=100090940131222&mibextid=ZbWKwL" 
+           target="_blank"
+           aria-label="Visit us on Facebook"
+           title="Facebook (External Link)"
+           rel="noopener noreferrer"
+           class="facebook"
+          >
+            <i class="bx bxl-facebook"></i>
+        </a>
+        <a 
+           href="https://www.instagram.com/os_code_community/" 
+           target="_blank" 
+           aria-label="Visit us on Instagram"
+           title="Instagram (External Link)"
+           rel="noopener noreferrer"
+           class="instagram"
+          >
+            <i class="bx bxl-instagram"></i>
+        </a>
+        <a 
+           href="https://www.youtube.com/@oscodecommunity" 
+           target="_blank" 
+           aria-label="Visit us on Youtube"
+           title="Linkedin (External Link)"
+           rel="noopener noreferrer"
+           class="youtube"
+          >
+            <i class="fab fa-youtube"></i>
+        </a>
+        <a 
+           href="https://www.linkedin.com/company/oscode/" 
+           target="_blank" 
+           aria-label="Visit us on Linkedin"
+           title="Linkedin (External Link)"
+           rel="noopener noreferrer"
+           class="linkedin"
+          >
+            <i class="bx bxl-linkedin"></i>
+        </a>
+        <a 
+           href="https://discord.com/channels/945676223101698060" 
+           target="_blank" 
+           aria-label="Join with us on Discord"
+           title="Discord (External Link)"
+           rel="noopener noreferrer"
+           class="discord"
+          >
+           <i class="fa-brands fa-discord"></i>
+        </a>
       </div>
 
       <div class="me-md-auto text-md-start crMod">


### PR DESCRIPTION
## Closes

Closes #709 


## Description
- Added `aria-label` attribute for social anchors like github & twitter
- The `aria-label` attribute is important for screen readers because it provides a text label for an object, such as `a` with social icons. When a screen reader encounters the object, the `aria-label` text is read so that the user will know what it is. 
- This is important for people who are blind or have low vision, as they rely on screen readers to access the web.
- Improved `title` attribute's data, because the title attribute is intended to provide additional information to screen reader users.
- And along with that i added `rel` for the anchors which are lacking them to ensure best practices for crawlers
- Because adding the `rel="noopener noreferrer"` attribute can help to protect this website from security vulnerabilities and improve performance. It is a good practice to use this attribute on all external links.
- Overall this PR is intended to make necessary changes to meet best practices for crawlers along with improving accessibility for social anchors

## Screenshots
- We can't take screenshots of accessibility changes rather than code changes, Accessibility changes are often invisible to the user because it's intended to guide disabled people

## Checklist:

<!--
<!-- Tick the checkboxes to ensure you've done everything correctly => [x] represents a checkbox  -->

- [x] I have linked the PR to the correct issue.
- [x] I have read the [Contribution Guidelines](https://github.com/OSCode-Community/OSCodeCommunitySite/blob/master/CONTRIBUTING.md)
- [x] I have built and tested the changes, and they do not break or show any errors.

<!--
Thank you for contributing to OSCodeCommunitySite! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
