### PR TITLE
Automatically label the issues

### DIFF
--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -1,0 +1,32 @@
+name: Add Labels to Issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-labels:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Add 'gssoc23' Label to Issue
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const issueNumber = context.payload.issue.number;
+            const label = 'gssoc23';
+            const addLabelParams = {
+              owner: owner,
+              repo: repo,
+              issue_number: issueNumber,
+              labels: [label]
+            };
+            await github.issues.addLabels(addLabelParams);
+            console.log(`Added the 'gssoc23' label to Issue #${issueNumber}.`);


### PR DESCRIPTION
## Closes

* Closes #864 

<!-- Replace <`issue_number`> with the Issue number to link it with this PR -->
<!-- Example: Closes #1-->

<!-- #1 stands for the issue number you are fixing -->

## Description

Added the automatic label issue workflow. Whenever a new issue will be created, a gssoc23 label will be added automatically by GitHub actions.

## Checklist:

<!--
<!-- Tick the checkboxes to ensure you've done everything correctly => [x] represents a checkbox  -->

- [x] I have linked the PR to the correct issue.
- [x] I have read the [Contribution Guidelines](https://github.com/OSCode-Community/OSCodeCommunitySite/blob/master/CONTRIBUTING.md)
- [x] I have built and tested the changes, and they do not break or show any errors.

<!--
Thank you for contributing to OSCodeCommunitySite!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
