### PR TITLE
fix: incorrect text color applied for headings 🛠️

### DIFF
--- a/assets/css/gallery.css
+++ b/assets/css/gallery.css
@@ -2,7 +2,6 @@
 ---------------------------*/
 
 .number {
-  color: rgb(24, 21, 21) !important;
   text-shadow: 2px 2px 3px rgb(77, 76, 76);
   font-size: 40px;
   margin-top: 40px;


### PR DESCRIPTION
## Close #1070 

## Description
- Fixed the incorrect color applied for headings on OSCODE Website

## Screenshots

![image](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/92252895/8933dff3-3731-49bb-872b-39896bdc4b0f)

## Checklist:

- [x] I have linked the PR to the correct issue.
- [x] I have read the [Contribution Guidelines](https://github.com/OSCode-Community/OSCodeCommunitySite/blob/master/CONTRIBUTING.md)
- [x] I have built and tested the changes, and they do not break or show any errors.
