### PR TITLE
feat: made social anchors accessible 🚀

### DIFF
--- a/chapters/chapter.html
+++ b/chapters/chapter.html
@@ -356,20 +356,66 @@
         <div class="container py-4 modifiedFooter">
             <div class="social-links text-md-end pt-3 pt-md-0 socialLinkMod">
                 <div class="textSocials">Stay in the loop?</div>
-                <a href="https://twitter.com/oscodecommunity" target="_blank" class="twitter"><i
-                        class="bx bxl-twitter"></i></a>
-                <a href="https://www.facebook.com/profile.php?id=100090940131222&mibextid=ZbWKwL" target="_blank"
-                    class="facebook"><i class="bx bxl-facebook"></i></a>
-                <a href="https://www.instagram.com/os_code_community/" target="_blank" class="instagram"><i
-                        class="bx bxl-instagram"></i></a>
-                <a href="https://www.youtube.com/@oscodecommunity" target="_blank" class="youtube"><i
-                        class="fab fa-youtube"></i></a>
-                <a href="https://www.linkedin.com/company/oscode/" target="_blank" class="linkedin"><i
-                        class="bx bxl-linkedin"></i></a>
-
-                <a href="https://discord.com/channels/945676223101698060" target="_blank" class="discord"><i
-                        class="bi bi-discord"></i></a>
-
+                <a 
+                    href="https://twitter.com/oscodecommunity" 
+                    target="_blank" 
+                    class="twitter"
+                    aria-label="Follow us on Twitter"
+                    title="Twitter (External Link)"
+                    rel="noopener noreferrer"
+                >
+                    <i class="bx bxl-twitter"></i>
+                </a>
+                <a 
+                    href="https://www.facebook.com/profile.php?id=100090940131222&mibextid=ZbWKwL" 
+                    target="_blank"
+                    class="facebook"
+                    aria-label="Follow us on Facebook"
+                    title="Facebook (External Link)"
+                    rel="noopener noreferrer"
+                >
+                    <i class="bx bxl-facebook"></i>
+                </a>
+                <a 
+                    href="https://www.instagram.com/os_code_community/" 
+                    target="_blank" 
+                    class="instagram"
+                    aria-label="Follow us on Instagram"
+                    title="Instagram (External Link)"
+                    rel="noopener noreferrer"
+                >
+                    <i class="bx bxl-instagram"></i>
+                </a>
+                <a 
+                    href="https://www.youtube.com/@oscodecommunity" 
+                    target="_blank" 
+                    class="youtube"
+                    aria-label="Follow us on Youtube"
+                    title="Youtube (External Link)"
+                    rel="noopener noreferrer"
+                >
+                    <i class="fab fa-youtube"></i>
+                </a>
+                <a 
+                    href="https://www.linkedin.com/company/oscode/" 
+                    target="_blank" 
+                    class="linkedin"
+                    aria-label="Follow us on Linkedin"
+                    title="Linkedin (External Link)"
+                    rel="noopener noreferrer"
+                >
+                    <i class="bx bxl-linkedin"></i>
+                </a>
+                <a 
+                    href="https://discord.com/channels/945676223101698060" 
+                    target="_blank" 
+                    class="discord"
+                    aria-label="Join with us on Discord"
+                    title="Discord (External Link)"
+                    rel="noopener noreferrer"
+                >
+                    <i class="bi bi-discord"></i>
+                </a>
             </div>
 
             <div class="me-md-auto text-md-start crMod">


### PR DESCRIPTION
## Close #1129 

## Description
- Added `aria-label` attribute for social anchors like github & twitter
- The `aria-label` attribute is important for screen readers because it provides a text label for an object, such as `a` with social icons. When a screen reader encounters the object, the `aria-label` text is read so that the user will know what it is. 
- This is important for people who are blind or have low vision, as they rely on screen readers to access the web.
- Improved `title` attribute's data, because the title attribute is intended to provide additional information to screen reader users.
- And along with that i added `rel` for the anchors which are lacking them to ensure best practices for crawlers
- Because adding the `rel="noopener noreferrer"` attribute can help to protect this website from security vulnerabilities and improve performance. It is a good practice to use this attribute on all external links.
- Overall this PR is intended to make necessary changes to meet best practices for crawlers along with improving accessibility for social anchors

## Screenshots
- We can't take screenshots of accessibility changes rather than code changes, Accessibility changes are often invisible to the user because it's intended to guide disabled people

## Note to reviewers
- This PR comes under adding a new feature to codebase, so make sure to add `level3` label during merging this PR.

## Checklist:

- [x] I have linked the PR to the correct issue.
- [x] I have read the [Contribution Guidelines](https://github.com/OSCode-Community/OSCodeCommunitySite/blob/master/CONTRIBUTING.md)
- [x] I have built and tested the changes, and they do not break or show any errors.