### PR TITLE
fix: broken images links for institutes on chapter page 🛠

### DIFF
--- a/chapters/chapter.html
+++ b/chapters/chapter.html
@@ -184,7 +184,7 @@
                             <div class="card mb-3 school-animation hidden">
                                 <div class="row g-0">
                                     <div class="col-md-3">
-                                        <img src="https://images.shiksha.com/mediadata/images/1492686515phpAJymFo_g.webp"
+                                        <img src="https://upload.wikimedia.org/wikipedia/commons/f/ff/SJC-Institute-of-Technology.jpg"
                                             class="img-fluid rounded-start" alt="...">
                                     </div>
                                     <div class="col-md-9">
@@ -200,7 +200,7 @@
                             <div class="card mb-3 school-animation hidden">
                                 <div class="row g-0">
                                     <div class="col-md-3">
-                                        <img src="https://images.shiksha.com/mediadata/images/1552902664php6IZLcB.webp"
+                                        <img src="https://www.mbacollegesbangalore.in/wp-content/uploads/2001/12/Sambhram-Institute-of-Technology-1.jpg"
                                             class="img-fluid rounded-start" alt="...">
                                     </div>
                                     <div class="col-md-9">
@@ -246,7 +246,7 @@
                             <div class="card mb-3 school-animation hidden">
                                 <div class="row g-0">
                                     <div class="col-md-3">
-                                        <img src="https://www.collegebatch.com/static/clg-gallery/vemana-institute-of-technology-bangalore-214131.webp"
+                                        <img src="http://www.vipt.edu.in/images/facilities-10.jpg"
                                             class="img-fluid rounded-start" alt="...">
                                     </div>
                                     <div class="col-md-9">


### PR DESCRIPTION
## Close #1136 

## Description
- This PR is about fixing the broken source links of images for Institutes on `chapter.html` page

## Screenshots

https://github.com/OSCode-Community/OSCodeCommunitySite/assets/92252895/b235749b-3a08-4536-9f42-94f4bd03e9ef

## Checklist:
- [x] I have linked the PR to the correct issue.
- [x] I have read the [Contribution Guidelines](https://github.com/OSCode-Community/OSCodeCommunitySite/blob/master/CONTRIBUTING.md)
- [x] I have built and tested the changes, and they do not break or show any errors.