### PR TITLE
fix: image disortion on gallery page 🛠

### DIFF
--- a/assets/css/gallery.css
+++ b/assets/css/gallery.css
@@ -11,35 +11,41 @@
 }
 #gallery {
   background-image: linear-gradient(
-    to right,
-    #0f0c29,
-    #302b63,
-    #24243e,
-    rgb(69, 69, 107)
-  );
+                    to right,
+                    #0f0c29,
+                    #302b63,
+                    #24243e,
+                    rgb(69, 69, 107)
+                  );
 }
 .image-slideshow {
   max-width: 700px;
-transition:  3s ease-in;
+  transition:  3s ease-in;
   margin: auto;
   position: relative;
   box-shadow: rgba(0, 0, 0, 0.56) 0px 22px 70px 4px;
   cursor: pointer;
-  box-shadow: rgba(17, 17, 26, 0.1) 0px 4px 16px, rgba(17, 17, 26, 0.1) 0px 8px 24px, rgba(17, 17, 26, 0.1) 0px 16px 56px;
+  box-shadow: rgba(17, 17, 26, 0.1) 0px 4px 16px, 
+              rgba(17, 17, 26, 0.1) 0px 8px 24px, 
+              rgba(17, 17, 26, 0.1) 0px 16px 56px;
   margin-top: 40px;
 }
 .image-slideshow img {
   width: 100%;
   box-shadow: rgba(0, 0, 0, 0.17) 0px -23px 25px 0px inset,
-    rgba(0, 0, 0, 0.15) 0px -36px 30px 0px inset,
-    rgba(0, 0, 0, 0.1) 0px -79px 40px 0px inset, rgba(0, 0, 0, 0.06) 0px 2px 1px,
-    rgba(0, 0, 0, 0.09) 0px 4px 2px, rgba(0, 0, 0, 0.09) 0px 8px 4px,
-    rgba(0, 0, 0, 0.09) 0px 16px 8px, rgba(0, 0, 0, 0.09) 0px 32px 16px;
+              rgba(0, 0, 0, 0.15) 0px -36px 30px 0px inset,
+              rgba(0, 0, 0, 0.1) 0px -79px 40px 0px inset, 
+              rgba(0, 0, 0, 0.06) 0px 2px 1px,
+              rgba(0, 0, 0, 0.09) 0px 4px 2px, 
+              rgba(0, 0, 0, 0.09) 0px 8px 4px,
+              rgba(0, 0, 0, 0.09) 0px 16px 8px, 
+              rgba(0, 0, 0, 0.09) 0px 32px 16px;
+  object-fit: cover;
 }
 .image-slideshow img:hover{
   transition:  3s ease-in;
   box-shadow: rgba(0, 0, 0, 0.56) 0px 22px 70px 4px;
-transform:scale(1.1);
+  transform: scale(1.1);
 }
 .image-slideshow:hover {
   box-shadow: rgba(0, 0, 0, 0.56) 0px 22px 70px 4px;


### PR DESCRIPTION
## Close #1162 

## Description
- Fixed the image disortion happened for images on gallery page, and linted the css too.

## Screenshots
|||
| :---: | :----: |
| **BEFORE**  | ![Screenshot 2023-07-22 at 12-35-37 OS-CODE Events](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/92252895/4c03c57d-8554-4387-a77d-e7b1caa88be2) |
| **AFTER** | ![Screenshot 2023-07-22 at 12-36-31 OS-CODE Events](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/92252895/d0e67ef0-ae34-4d6f-a215-0674afbbf1a6) |

## Checklist:

- [x] I have linked the PR to the correct issue.
- [x] I have read the [Contribution Guidelines](https://github.com/OSCode-Community/OSCodeCommunitySite/blob/master/CONTRIBUTING.md)
- [x] I have built and tested the changes, and they do not break or show any errors.

<!--
Thank you for contributing to OSCodeCommunitySite!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
