### PR TITLE
fix: incorrect alignment of footer logo and os code name 🛠

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1519,11 +1519,14 @@ a:hover i {
 }
 
 #footer .footer-top .footer-contact h3 {
-  margin-top: 0px;
   font-size: 26px;
   font-family: "Google Sans", sans-serif;
   line-height: 1;
   font-weight: 700;
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+  margin-top: -.75rem;
 }
 
 #footer .footer-top .footer-contact h3 span {


### PR DESCRIPTION
## Close #1191 

## Description
- Fixes the incorrect alignment of heading and os-code logo on footer to improve UI.

## Screenshots

|||
|:----:|:----:|
|![image](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/92252895/7e761ba1-14a0-4941-9985-1767e8787328) | ![Screenshot 2023-07-24 at 22-35-00 OS Code](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/92252895/f2fa89bd-6c0b-48c7-952f-540b5e0fa611) 


## Checklist:

<!--
<!-- Tick the checkboxes to ensure you've done everything correctly => [x] represents a checkbox  -->

- [x] I have linked the PR to the correct issue.
- [x] I have read the [Contribution Guidelines](https://github.com/OSCode-Community/OSCodeCommunitySite/blob/master/CONTRIBUTING.md)
- [x] I have built and tested the changes, and they do not break or show any errors.

<!--
Thank you for contributing to OSCodeCommunitySite!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
