### PR TITLE
eventpagefootersocialicons

### DIFF
--- a/events/events.html
+++ b/events/events.html
@@ -777,21 +777,29 @@
         <div class="textSocials">Stay in the loop?</div>
         <div class="socialIcons">
           <a href="https://wa.me/7975954835 " target="_blank" aria-label="Visit us on Whatapp"
-            title="Whatapp (External Link)" rel="noopener noreferrer" class="twitter">
+            title="Whatapp (External Link)" rel="noopener noreferrer" class="icon whatsapp">
+            <div class="tooltip">Whatsapp</div>
             <i class="bi bi-whatsapp"></i>
           </a>
-        <a href="https://twitter.com/oscodecommunity" target="_blank" class="twitter"><i class="bx bxl-twitter"></i></a>
+        <a href="https://twitter.com/oscodecommunity" target="_blank" class="icon twitter">
+          <div class="tooltip">Twitter</div><i class="bx bxl-twitter"></i></a>
         <a href="https://www.facebook.com/profile.php?id=100090940131222&mibextid=ZbWKwL" target="_blank"
-          class="facebook"><i class="bx bxl-facebook"></i></a>
-        <a href="https://www.instagram.com/os_code_community/" target="_blank" class="instagram"><i
+          class="icon facebook">
+          <div class="tooltip">facebook</div><i class="bx bxl-facebook"></i></a>
+        <a href="https://www.instagram.com/os_code_community/" target="_blank" class="icon instagram">
+          <div class="tooltip">Instagram</div><i
             class="bx bxl-instagram"></i></a>
-        <a href="https://www.youtube.com/@oscodecommunity" target="_blank" class="youtube"><i
+        <a href="https://www.youtube.com/@oscodecommunity" target="_blank" class="icon youtube">
+          <div class="tooltip">youtube</div><i
             class="fab fa-youtube"></i></a>
-        <a href="https://www.linkedin.com/company/oscode/" target="_blank" class="linkedin"><i
+        <a href="https://www.linkedin.com/company/oscode/" target="_blank" class="icon linkedin">
+          <div class="tooltip">Linkedin</div><i
             class="bx bxl-linkedin"></i></a>
-        <a href="https://discord.com/channels/945676223101698060" target="_blank" class="discord"><i
+        <a href="https://discord.com/channels/945676223101698060" target="_blank" class="icon discord">
+          <div class="tooltip">Discord</div><i
             class="bi bi-discord"></i></a>
-        <a href="https://github.com/OSCode-Community/OSCodeCommunitySite" target="_blank" class="github"><i
+        <a href="https://github.com/OSCode-Community/OSCodeCommunitySite" target="_blank" class="icon github">
+          <div class="tooltip">Github</div><i
               class="bi bi-github"></i></a>
         </div>
       </div>


### PR DESCRIPTION
## Closes

Closes #1187 

## Description

I have added the tooltip on the events page also I have changed the color of WhatsApp to green before it was blue which was a bug

## Screenshots

![Screenshot (502)](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/124120102/ea34af82-85de-429e-aaa3-e2b0d1a9301f)


## Note to reviewers

<!-- Add notes to reviewers if applicable -->

## Checklist:

<!--
<!-- Tick the checkboxes to ensure you've done everything correctly => [x] represents a checkbox  -->

- [x] I have linked the PR to the correct issue.
- [x] I have read the [Contribution Guidelines](https://github.com/OSCode-Community/OSCodeCommunitySite/blob/master/CONTRIBUTING.md)
- [x] I have built and tested the changes, and they do not break or show any errors.

<!--
Thank you for contributing to OSCodeCommunitySite!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
