### PR TITLE
fix: lack of contributors link on login page 🛠

### DIFF
--- a/login/login.html
+++ b/login/login.html
@@ -108,6 +108,14 @@
             <a
               class="nav-link scrollto"
               style="text-decoration: none"
+              href="/contributors/contributor.html"
+              >CONTRIBUTORS</a
+            >
+          </li>
+          <li>
+            <a
+              class="nav-link scrollto"
+              style="text-decoration: none"
               href="/#contact"
               >CONTACT</a
             >


### PR DESCRIPTION
## Close #1254 

## Description
- Added the contributors navigational link to the login page's nav bar for proper navigation.

## Checklist:

<!--
<!-- Tick the checkboxes to ensure you've done everything correctly => [x] represents a checkbox  -->

- [x] I have linked the PR to the correct issue.
- [x] I have read the [Contribution Guidelines](https://github.com/OSCode-Community/OSCodeCommunitySite/blob/master/CONTRIBUTING.md)
- [x] I have built and tested the changes, and they do not break or show any errors.

<!--
Thank you for contributing to OSCodeCommunitySite!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
