### PR TITLE
fix: incorrect padding for privacy page 🛠

### DIFF
--- a/assets/css/privacy.css
+++ b/assets/css/privacy.css
@@ -2,6 +2,8 @@ body {
     margin: 0;
     font-family: 'Montserrat', sans-serif;
     line-height: 2;
+    min-height: 100vh;
+    text-rendering: optimizeSpeed;
 }
 .logo1 {
      padding: 5px;
@@ -31,6 +33,7 @@ a:hover {
     text-align: center;
     /* background: url("./assets/img/background/bg9.jpg"); */
     background-color: purple;
+    padding-bottom: 0rem;
 }
 
 h1,
@@ -41,6 +44,12 @@ h3 {
     line-height: 0.3em;
     letter-spacing: 2px;
     font-family: 'Noto Serif', serif;
+}
+
+h1 {
+    line-height: 4rem;
+    margin: unset;
+    margin: 2rem;
 }
 
 #main,
@@ -59,7 +68,7 @@ h3 {
 #updates,
 #notice,
 #review {
-    /* padding: 25px 50px 0px 70px; */
+    padding: 25px 50px 0px 70px;
     font-family: 'Montserrat', sans-serif;
 }
 


### PR DESCRIPTION
## Close #1256 

## Description
- This PR is about fixing the improper and inconsistent padding, margin values  applied for elements on Privacy Page

## Screenshots

|**BEFORE** | **AFTER** |
|:---:|:---:|
| ![image](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/92252895/86ff03b0-bfeb-46cd-b8ea-754ad35ee1f2) | ![Screenshot 2023-07-25 at 22-33-04 OS-Code Privacy Policy](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/92252895/809e06cf-ac04-40ba-b344-902c81763487) |

## Checklist:

<!--
<!-- Tick the checkboxes to ensure you've done everything correctly => [x] represents a checkbox  -->

- [x] I have linked the PR to the correct issue.
- [x] I have read the [Contribution Guidelines](https://github.com/OSCode-Community/OSCodeCommunitySite/blob/master/CONTRIBUTING.md)
- [x] I have built and tested the changes, and they do not break or show any errors.

<!--
Thank you for contributing to OSCodeCommunitySite!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
