### PR TITLE
fix: wrong navigational link for events page 🛠

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1811,6 +1811,16 @@ a:hover i {
   transform: scaleX(1);
 }
 
+.card-text {
+  font-weight: 600 !important;
+  font-family: sans-serif !important;
+  font-size: 1rem;
+}
+
+.event_box {
+  min-height: 200px !important;
+}
+
 @media (max-width: 767px) {
   /* Center align the footer for small devices */
   footer {

--- a/index.html
+++ b/index.html
@@ -144,13 +144,13 @@
     <i class="bi bi-list mobile-nav-toggle"></i>
     <div id="navbar" class="navbar order-last order-lg-0 me-4">
       <ul class="nav-list">
-        <li><a class="nav-link scrollto active"  style="text-decoration: none;" href="#hero">HOME</a></li>
-        <li><a class="nav-link scrollto" style="text-decoration: none;" href="#mainabout">ABOUT</a></li>
-        <li><a class="nav-link scrollto" style="text-decoration: none;" href="chapters/chapter.html">CHAPTERS</a></li>
-        <li><a class="nav-link scrollto" style="text-decoration: none;" href="https://blog.oscode.co.in/">BLOGS</a></li>
-        <li><a class="nav-link scrollto" href="assets/gallery.html" style="text-decoration: none;">GALLERY</a></li>
-        <li><a class="nav-link scrollto" href="http://127.0.0.1:5500/events/events.html" style="text-decoration: none;">EVENTS</a></li>
-        <li><a class="nav-link scrollto" href="contact/contact.html" style="text-decoration: none;">CONTACT</a></li>
+        <li><a class="nav-link scrollto active" href="#hero">HOME</a></li>
+        <li><a class="nav-link scrollto" href="#mainabout">ABOUT</a></li>
+        <li><a class="nav-link scrollto" href="chapters/chapter.html">CHAPTERS</a></li>
+        <li><a class="nav-link scrollto" href="https://blog.oscode.co.in/">BLOGS</a></li>
+        <li><a class="nav-link scrollto" href="assets/gallery.html">GALLERY</a></li>
+        <li><a class="nav-link scrollto" href="events/events.html">EVENTS</a></li>
+        <li><a class="nav-link scrollto" href="contact/contact.html">CONTACT</a></li>
         <li>
           <a
             class="nav-link scrollto"


### PR DESCRIPTION
## Close #1272 

## Description
- Fixed the wrong navigational link of Events page on OS-CODE Website


## Checklist:

<!--
<!-- Tick the checkboxes to ensure you've done everything correctly => [x] represents a checkbox  -->

- [x] I have linked the PR to the correct issue.
- [x] I have read the [Contribution Guidelines](https://github.com/OSCode-Community/OSCodeCommunitySite/blob/master/CONTRIBUTING.md)
- [x] I have built and tested the changes, and they do not break or show any errors.

<!--
Thank you for contributing to OSCodeCommunitySite!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
