### PR TITLE
fix: card cut-off on events page 🛠

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1811,6 +1811,16 @@ a:hover i {
   transform: scaleX(1);
 }
 
+.card-text {
+  font-weight: 600 !important;
+  font-family: sans-serif !important;
+  font-size: 1rem;
+}
+
+.event_box {
+  min-height: 200px !important;
+}
+
 @media (max-width: 767px) {
   /* Center align the footer for small devices */
   footer {


### PR DESCRIPTION
## Close #1275 

## Description
- This PR fixes the cutted of cards by adding appropriate styles rules in order to prevent the card from being cutting of.

## Screenshots
|BEFORE|AFTER|
|:---:|:----:|
| ![image](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/92252895/ab1a6a5f-7dd6-4661-b1f0-3ffdfe03bf2a) | ![image](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/92252895/64107022-e10a-4a07-8a6b-601980260efd) |

## Checklist:

<!--
<!-- Tick the checkboxes to ensure you've done everything correctly => [x] represents a checkbox  -->

- [x] I have linked the PR to the correct issue.
- [x] I have read the [Contribution Guidelines](https://github.com/OSCode-Community/OSCodeCommunitySite/blob/master/CONTRIBUTING.md)
- [x] I have built and tested the changes, and they do not break or show any errors.

<!--
Thank you for contributing to OSCodeCommunitySite!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
