### PR TITLE
fix: Placeholder Collapsing 🎉

### DIFF
--- a/index.html
+++ b/index.html
@@ -991,9 +991,9 @@
                 <div class="col form-group px-2">
                   <div>
                     <label class="label-name">
-                      <span class="content-name">Email</span>
+                      <span class="content-name"></span>
                     </label>
-                    <input type="email" autocomplete="email" class="form-control" name="email" id="email" required />
+                    <input type="email" autocomplete="email" class="form-control" placeholder="Email" name="email" id="email" required />
                     <!-- <i class="fas fa-check-circle"></i> -->
                     <!-- <i class="fas fa-exclamation-circle"></i> -->
                   </div>
@@ -1003,9 +1003,9 @@
                 <div class="col form-group px-2">
                   <div>
                     <label class="label-name">
-                      <span class="content-name">Name</span>
+                      <span class="content-name"></span>
                     </label>
-                    <input type="text" autocomplete="name" name="name" class="form-control" id="name"
+                    <input type="text" autocomplete="name" name="name" placeholder="Name" class="form-control" id="name"
                       pattern="[a-zA-Z][a-zA-Z ]{2,}" title="Number Not Allowed" required />
                     <!-- <i class="fas fa-check-circle"></i> -->
                     <!-- <i class="fas fa-exclamation-circle"></i> -->
@@ -1017,18 +1017,18 @@
                 <div class="col form-group">
                   <div class="form-group">
                     <label class="label-name">
-                      <span class="content-name">College</span>
+                      <span class="content-name"></span>
                     </label>
-                    <input type="text" autocomplete="subject" class="form-control" name="College" id="college"
+                    <input type="text" autocomplete="subject" placeholder="College" class="form-control" name="College" id="college"
                       required />
                   </div>
                 </div>
                 <div class="col form-group">
                   <div>
                     <label class="label-name">
-                      <span class="content-name">Subject</span>
+                      <span class="content-name"></span>
                     </label>
-                    <input type="text" autocomplete="subject" class="form-control" name="subject" id="subject"
+                    <input type="text" autocomplete="subject" placeholder="Subject" class="form-control" name="subject" id="subject"
                       required />
                   </div>
                   <div class="spandiv" style="padding-top: 4px;"> <small class="small"></small></div>
@@ -1037,9 +1037,9 @@
                 <div class="col form-group">
                   <div>
                     <label class="label-name">
-                      <span class="content-name">Message</span>
+                      <span class="content-name"></span>
                     </label>
-                    <textarea class="form-control" autocomplete="message" id="message" name="message" rows="5"
+                    <textarea class="form-control" autocomplete="message" placeholder="Message" id="message" name="message" rows="5"
                       required></textarea>
                   </div>
                   <div class="spandiv" style="padding-top: 4px;"><small class="small"></small></div>


### PR DESCRIPTION
## Closes

Closes #1282 


## Description

### **When User is Enter The Text Then Placeholder and Input Text is overlapping each other i have solve this issue** 



## Screenshots[Video]

### **Before**

![image](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/85815172/b8fe811c-42f6-4a1a-b662-91eb95c27748)



### **After**

[screen-capture.webm](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/85815172/700d51df-9d26-4174-b1f1-0827679ab1ed)




<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->

## Checklist:

<!--
<!-- Tick the checkboxes to ensure you've done everything correctly => [x] represents a checkbox  -->

- [x] I have linked the PR to the correct issue.
- [x] I have read the [Contribution Guidelines](https://github.com/OSCode-Community/OSCodeCommunitySite/blob/master/CONTRIBUTING.md)
- [x] I have built and tested the changes, and they do not break or show any errors.

<!--
Thank you for contributing to OSCodeCommunitySite!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
