### PR TITLE
feat: Init the Auto Generate Changelog workflow. ⚡

### DIFF
--- a/.github/ISSUE_TEMPLATE/Refactor.yml
+++ b/.github/ISSUE_TEMPLATE/Refactor.yml
@@ -22,10 +22,10 @@ body:
     attributes:
       label: 'Checklist'
       options:
-        - label: 'I have checked the existing [issues](https://github.com/rupali-codes/LinksHub/issues).'
+        - label: 'I have checked the existing [issues](https://github.com/OSCode-Community/OSCodeCommunitySite/issues).'
           required: true
 
-        - label: 'I have read the [Contributing Guidelines](https://github.com/rupali-codes/LinksHub/blob/main/CONTRIBUTING.md).'
+        - label: 'I have read the [Contributing Guidelines](https://github.com/OSCode-Community/OSCodeCommunitySite/blob/b0b072d8bf6829633c4d9f587e4ffe6075cb9f8f/CODE_OF_CONDUCT.md).'
           required: true
 
         - label: "The changes don't break the code and don't introduce new functionality."

--- a/.github/workflows/change.yml
+++ b/.github/workflows/change.yml
@@ -1,0 +1,29 @@
+name: Changelog
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Conventional Changelog Action
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          output-file: "false"
+
+      - name: Create Release
+        uses: actions/create-release@v1
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.changelog.outputs.tag }}
+          release_name: ${{ steps.changelog.outputs.tag }}
+          body: ${{ steps.changelog.outputs.clean_changelog }}


### PR DESCRIPTION
## Closes

Closes #1338



## Description

### **Created `workflow` in `.github/workflow/Changelog.yml ` which automatically Generates The Logs base on **Conventional Commit**** 

## Screenshots

![image](https://github.com/Opentek-Org/opentek/assets/85815172/1aa5fffe-913c-45b2-8081-dccaccf0ebb7)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->

## Checklist:

<!--
<!-- Tick the checkboxes to ensure you've done everything correctly => [x] represents a checkbox  -->

- [x] I have linked the PR to the correct issue.
- [x] I have read the [Contribution Guidelines](https://github.com/OSCode-Community/OSCodeCommunitySite/blob/master/CONTRIBUTING.md)
- [x] I have built and tested the changes, and they do not break or show any errors.

<!--
Thank you for contributing to OSCodeCommunitySite!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
