### PR TITLE
Refactor:  Restart-Password.CSS ✨

### DIFF
--- a/assets/css/resetpass.css
+++ b/assets/css/resetpass.css
@@ -1,120 +1,114 @@
 * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-    text-decoration: none;
-    --header-height: 70px;
-  }
-  
-  .resetpass-container {
-    position: relative;
-    width:100%;
-    font-family: "Montserrat", sans-serif;
-    background-image: linear-gradient(
-      150deg,
-      #00a2e7,
-      #160078
-    );
-  }
-  
-  .resetpass-box { 
-    padding: 40px 40px 30px 40px;
-    background: rgba(0,0,0,.5);
-    box-sizing: border-box;
-    box-shadow: 0 15px 25px rgba(0,0,0,.6);
-    border-radius: 10px;
-  }
-  
-  .resetpasstxt {
-    font-size: 25px;
-    letter-spacing: 1px;
-    margin-bottom: 40px;
-    margin-top: unset;
-  }
-  
-  .form-container {
-    width: 100%;
-  }
-  
-  .form-container .user-box {
-    position: relative;
-  }
-  
-  .form-container .user-box input {
-    width: 100%;
-    padding: 10px 0;
-    font-size: 16px;
-    color: #fff;
-    margin-bottom: 30px;
-    border: none;
-    border-bottom: 1px solid #fff;
-    outline: none;
-    background: transparent;
-  }
-  .form-container .user-box label {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  text-decoration: none;
+  --header-height: 70px;
+}
+
+.resetpass-container {
+  position: relative;
+  width: 100%;
+  font-family: "Montserrat", sans-serif;
+  background-image: linear-gradient(150deg, #00a2e7, #160078);
+}
+
+.resetpass-box {
+  padding: 40px;
+  background: rgba(0, 0, 0, 0.5);
+  box-sizing: border-box;
+  box-shadow: 0 15px 25px rgba(0, 0, 0, 0.6);
+  border-radius: 10px;
+}
+
+.resetpasstxt {
+  font-size: 25px;
+  letter-spacing: 1px;
+  margin-bottom: 40px;
+  margin-top: 0;
+}
+
+.form-container {
+  width: 100%;
+}
+
+.form-container .user-box {
+  position: relative;
+}
+
+.form-container .user-box input {
+  width: 100%;
+  padding: 10px 0;
+  font-size: 16px;
+  color: #fff;
+  margin-bottom: 30px;
+  border: none;
+  border-bottom: 1px solid #fff;
+  outline: none;
+  background: transparent;
+}
+
+.form-container .user-box label {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 10px 0;
+  font-size: 16px;
+  color: #fff;
+  letter-spacing: 1px;
+  pointer-events: none;
+  transition: 0.5s;
+}
+
+.form-container .user-box input:focus ~ label,
+.form-container .user-box input:valid ~ label {
+  top: -20px;
+  left: 0;
+  color: #d8b8ff;
+  font-size: 14px;
+}
+
+.form-container .name-part {
+  flex-grow: 1;
+}
+
+button.submit-button[type="submit"] {
+  background-color: #7b2fff;
+  color: #fff;
+  border: none;
+  letter-spacing: 1px;
+  font-weight: 500;
+  font-size: 20px;
+  line-height: 30px;
+  border-radius: 45px;
+  padding: 12px 45px;
+  margin: 10px 0;
+  transition: all 0.3s ease;
+}
+
+button.submit-button[type="submit"]:hover {
+  background-color: white;
+  box-shadow: 0 0 20px 5px rgba(182, 139, 255, 0.6);
+  color: black;
+  transform: translateY(-2px);
+}
+
+@media only screen and (min-width: 580px) {
+  .resetpass-box {
     position: absolute;
-    top:0;
-    left: 0;
-    padding: 10px 0;
-    font-size: 16px;
-    color: #fff;
-    letter-spacing: 1px;
-    pointer-events: none;
-    transition: .5s;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 550px;
   }
-  
-  .form-container .user-box input:focus ~ label,
-  .form-container .user-box input:valid ~ label {
-    top: -20px;
-    left: 0;
-    color: #d8b8ff;
-    font-size: 14px;
+}
+
+@media only screen and (max-width: 580px) {
+  .resetpass-container {
+    padding-top: var(--header-height);
   }
-  
-  .form-container .name-part{
-    flex-grow: 1;
+  .resetpass-box {
+    margin: 15px;
+    width: calc(100% - 30px);
   }
-  
-  button.submit-button[type="submit"] {
-    background-color: #7b2fff;
-    color: #fff;
-    border: none;
-    letter-spacing: 1px;
-    font-weight: 500;
-    font-size: 20px;
-    line-height: 30px;
-    border-radius: 45px;
-    padding: 12px 45px;
-    margin: 10px 0;
-    transition: all 0.3s ease;
-  }
-  
-  button.submit-button[type="submit"]:hover {
-    background-color: white;
-    box-shadow: 0px 0 20px 5px rgba(182, 139, 255, 0.6);
-    color: black;
-    transform: translateY(-2px);
-  }
-    
-  @media only screen and (min-width: 580px) {
-    .resetpass-box {
-      position: absolute; 
-      top: 50%;
-      left:50%;
-      transform: translate(-50%,-50%);
-      width:550px;
-    }
-   
-  }
-  @media only screen and (max-width: 580px) {
-    .resetpass-container {
-      padding-top: var(--header-height);
-    }
-    .resetpass-box {
-      margin-top: 15px;
-      margin-bottom: 25px;
-      width: calc( 100% - 30px );
-    }
-    
-  }
-  
+}


### PR DESCRIPTION
## Closes

Closes #1382

<!-- Replace <`issue_number`> with the Issue number to link it with this PR -->
<!-- Example: Closes #1-->



## Description

**Description:**
Currently, the CSS code for the reset password page contains some redundant and unnecessary properties that can be refactored to improve readability and maintainability. The goal of this issue is to refactor the existing CSS code for the reset password page to make it cleaner and more efficient.

**Refactor Plan:**
1. Remove unnecessary units on `padding` for `.resetpass-box`.
2. Remove unnecessary `margin-top` value from `.resetpasstxt`.
3. Remove duplicate `width: 100%;` from `.form-container`.
4. Remove unnecessary `position: relative;` from `.form-container .user-box`.
5. Remove `background: transparent;` from `.form-container .user-box input` as it is not needed.
6. Remove `flex-grow: 1;` from `.form-container .name-part` as it doesn't seem to be used.
7. Remove unused CSS variables `--header height.





## Checklist:

<!--
<!-- Tick the checkboxes to ensure you've done everything correctly => [x] represents a checkbox  -->

- [x] I have linked the PR to the correct issue.
- [x] I have read the [Contribution Guidelines](https://github.com/OSCode-Community/OSCodeCommunitySite/blob/master/CONTRIBUTING.md)
- [x] I have built and tested the changes, and they do not break or show any errors.

<!--
Thank you for contributing to OSCodeCommunitySite!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
