### PR TITLE
Validation added on reset password form

### DIFF
--- a/assets/css/resetpass.css
+++ b/assets/css/resetpass.css
@@ -41,7 +41,8 @@
   padding: 10px 0;
   font-size: 16px;
   color: #fff;
-  margin-bottom: 30px;
+  margin-bottom: 20px;
+  margin-top: 10px;
   border: none;
   border-bottom: 1px solid #fff;
   outline: none;
@@ -111,4 +112,8 @@ button.submit-button[type="submit"]:hover {
     margin: 15px;
     width: calc(100% - 30px);
   }
+}
+.user-box .error-msg {
+  color: red;
+  margin-top: -10px;
 }

--- a/resetpass/resetpass.html
+++ b/resetpass/resetpass.html
@@ -149,6 +149,7 @@
               id="password"
             />
             <label for="oldpass">Old Password</label>
+            <span class="error-msg" id="passworderr"></span>
           </div>
 
           <div class="user-box">
@@ -160,6 +161,7 @@
               id="password1"
             />
             <label for="newpass">New Password</label>
+            <span class="error-msg" id="password1err"></span>
           </div>
 
           <div style="display: flex; align-items: center">
@@ -171,7 +173,7 @@
 
           <!-- reset pass button -->
           <div class="btn">
-            <button type="submit" class="submit-button cursor-pointer">
+            <button type="submit" class="submit-button cursor-pointer" onclick="handleSubmit()">
               Confirm
             </button>
           </div>

--- a/resetpass/resetpass.js
+++ b/resetpass/resetpass.js
@@ -1,9 +1,23 @@
 const oldpass = "";
 const newpass = "";
-
+var password = document.getElementById("password");
+var password1 = document.getElementById("password1");
+var passwderr = document.getElementById("passworderr");
+var passwd1err = document.getElementById("password1err");
 function handleSubmit(e) {
-  e.preventDefault();
-  // PostData();
+   console.log("called");
+       // Validation check
+   if(password.value =='')
+  { passwderr.innerText = "*Old password is required!";}
+  else if(password1.value =='')
+  { passwderr.innerText = ""; passwd1err.innerText = "*New password is required!";}
+  else
+  {
+   // PostData();
+   passwd1err.innerText="";
+   password.value='';
+   password1.value='';
+  }
 }
 
 function handleChange(e) {


### PR DESCRIPTION
## Closes

Closes #1393


## Description
Add empty validation on passwords
Error message shown below of each fields.


## Screenshots

<!-- Add all the screenshots which support your changes -->


![Screenshot (40)](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/75520947/48d686dd-41a5-4031-857b-ff594c8f1455)
![Screenshot (42)](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/75520947/a69b5eb0-ed7d-47e8-80cb-acf7faf8ab82)



## Checklist:

<!--
<!-- Tick the checkboxes to ensure you've done everything correctly => [x] represents a checkbox  -->

- [ x] I have linked the PR to the correct issue.
- [ x] I have read the [Contribution Guidelines](https://github.com/OSCode-Community/OSCodeCommunitySite/blob/master/CONTRIBUTING.md)
- [ x] I have built and tested the changes, and they do not break or show any errors.

@Vaishnavi-Patil2211 issue#1393 resolved!!
