### PR TITLE
fix: wrong repository navigation link on refactor issue template 🛠️

### DIFF
--- a/.github/ISSUE_TEMPLATE/Refactor.yml
+++ b/.github/ISSUE_TEMPLATE/Refactor.yml
@@ -22,10 +22,10 @@ body:
     attributes:
       label: 'Checklist'
       options:
-        - label: 'I have checked the existing [issues](https://github.com/rupali-codes/LinksHub/issues).'
+        - label: 'I have checked the existing [issues](https://github.com/OSCode-Community/OSCodeCommunitySite/issues).'
           required: true
 
-        - label: 'I have read the [Contributing Guidelines](https://github.com/rupali-codes/LinksHub/blob/main/CONTRIBUTING.md).'
+        - label: 'I have read the [Contributing Guidelines](https://github.com/OSCode-Community/OSCodeCommunitySite/blob/master/CONTRIBUTING.md).'
           required: true
 
         - label: "The changes don't break the code and don't introduce new functionality."


### PR DESCRIPTION
## Close #1440


## Checklist:

<!--
<!-- Tick the checkboxes to ensure you've done everything correctly => [x] represents a checkbox  -->

- [x] I have linked the PR to the correct issue.
- [x] I have read the [Contribution Guidelines](https://github.com/OSCode-Community/OSCodeCommunitySite/blob/master/CONTRIBUTING.md)
- [x] I have built and tested the changes, and they do not break or show any errors.

<!--
Thank you for contributing to OSCodeCommunitySite!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
