### PR TITLE
feat:  Create change.yml ✨

### DIFF
--- a/.github/workflows/change.yml
+++ b/.github/workflows/change.yml
@@ -1,0 +1,29 @@
+name: Changelog
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Conventional Changelog Action
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          output-file: "false"
+
+      - name: Create Release
+        uses: actions/create-release@v1
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.changelog.outputs.tag }}
+          release_name: ${{ steps.changelog.outputs.tag }}
+          body: ${{ steps.changelog.outputs.clean_changelog }}


### PR DESCRIPTION
## Closes

Closes  #1338


<!-- #1 stands for the issue number you are fixing -->

## Description

This workflow, named "Changelog," is designed to automate the process of generating a changelog and creating a release in a GitHub repository. Let's break down the workflow step by step:

1. **Trigger**: The workflow is triggered when a push event occurs on the `main` branch.

2. **Job**: The workflow contains a single job named `changelog`.

3. **Runs on**: The job runs on the `ubuntu-latest` virtual environment.

4. **Step 1**: The first step in the job is `actions/checkout@v2`, which checks out the code from the repository, allowing subsequent steps to access the repository files.

5. **Step 2**: The second step is named "Conventional Changelog Action." This step uses the `TriPSs/conventional-changelog-action@v3` GitHub Action, which is a third-party action used to generate a conventional changelog based on the commit messages. It takes the following inputs (with values provided using the `with` keyword):

   - `github-token`: This is a secret environment variable, `secrets.GITHUB_TOKEN`, automatically provided by GitHub Actions. It grants the necessary permissions for the action to access the repository.
   - `output-file`: This is set to `"false"`, indicating that the generated changelog will not be written to a file but rather used in the next steps directly.

   The action generates the changelog, and its outputs are stored for later use.

6. **Step 3**: The third step is named "Create Release." This step uses the `actions/create-release@v1` GitHub Action, which is an official GitHub Action used to create a new release in the repository. However, this step is conditional and will only run under the following condition:

   ```yaml
   if: ${{ steps.changelog.outputs.skipped == 'false' }}
   ```

   This condition checks if the previous step's output (`steps.changelog.outputs.skipped`) is equal to `'false'`. This is likely a value set by the "Conventional Changelog Action" step in case the changelog generation was not skipped.

   If the condition is met, the "Create Release" step will run. It takes the following inputs (with values provided using the `with` keyword):

   - `tag_name`: This is set to the output of the "Conventional Changelog Action" step (`steps.changelog.outputs.tag`). It likely contains the version or tag name extracted from the changelog generation.
   - `release_name`: This is also set to the output of the "Conventional Changelog Action" step (`steps.changelog.outputs.tag`), which is likely the same as the `tag_name`.
   - `body`: This is set to the output of the "Conventional Changelog Action" step (`steps.changelog.outputs.clean_changelog`). It likely contains the clean and formatted changelog that will be used as the release notes.

That's the step-by-step explanation of the "Changelog" workflow. In summary, the workflow generates a changelog using the "Conventional Changelog Action" and, if changelog generation was not skipped, creates a new release with the changelog as the release notes using the "Create Release" action.





<!-- List all the proposed changes in your PR -->

## Screenshots

![image](https://github.com/OSCode-Community/OSCodeCommunitySite/assets/85815172/886491df-3b13-48d7-80f0-5d304db6630b)



<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->

## Checklist:

<!--
<!-- Tick the checkboxes to ensure you've done everything correctly => [x] represents a checkbox  -->

- [x] I have linked the PR to the correct issue.
- [x] I have read the [Contribution Guidelines](https://github.com/OSCode-Community/OSCodeCommunitySite/blob/master/CONTRIBUTING.md)
- [x] I have built and tested the changes, and they do not break or show any errors.

<!--
Thank you for contributing to OSCodeCommunitySite!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
